### PR TITLE
Improvements for the CLI

### DIFF
--- a/goodbot/cli.py
+++ b/goodbot/cli.py
@@ -77,7 +77,7 @@ def setup(config: str, project_path: str) -> None:
     to_create = funcmodule.create_dirs_list(conf_info)
 
     path = funcmodule.create_dirs(
-        to_create, PROJECT_ROOT / pathlib.Path(project_path)
+        to_create, project_path, PROJECT_ROOT / pathlib.Path(project_path)
     )
 
     # Splitting script

--- a/goodbot/cli.py
+++ b/goodbot/cli.py
@@ -77,7 +77,7 @@ def setup(config: str, project_path: str) -> None:
     to_create = funcmodule.create_dirs_list(conf_info)
 
     path = funcmodule.create_dirs(
-        to_create, PROJECT_ROOT / pathlib.Path(project_path) / pathlib.Path(project_name)
+        to_create, PROJECT_ROOT / pathlib.Path(project_path)
     )
 
     # Splitting script

--- a/goodbot/cli.py
+++ b/goodbot/cli.py
@@ -83,7 +83,7 @@ def setup(config: str, project_path: str) -> None:
     # Splitting script
     funcmodule.split_config(parsed, path)
 
-    click.echo(f"Your project has been setup at: {path}")
+    click.echo(f"Your project has been setup at: {project_path}")
 
 
 @click.command()

--- a/goodbot/funcmodule.py
+++ b/goodbot/funcmodule.py
@@ -218,6 +218,9 @@ def create_dirs(
 
                 os.mkdir(project_dir)
 
+            else:
+                sys.exit()
+
         else:
             sys.exit()
 

--- a/goodbot/funcmodule.py
+++ b/goodbot/funcmodule.py
@@ -172,7 +172,7 @@ def create_dirs_list(all_confs: Dict[int, Dict[str, list]]) -> List[dict]:
 
 
 def create_dirs(
-    directories: list, project_dir: Union[str, Path] = "my_project"
+        directories: list, host_dir: Union[str, Path], project_dir: Union[str, Path] = "my_project"
 ) -> Path:
     """Creates directories for the project. This function should be
     called on the host's computer, not in the container. Docker will
@@ -202,14 +202,14 @@ def create_dirs(
 
     if project_dir.is_dir():
 
-        click.echo(f"Directory {project_dir} exists!")
-        resp = input(f"Would you like to overwrite {project_dir}?: ")
+        click.echo(f"Directory {host_dir} exists!")
+        resp = input(f"Would you like to overwrite {host_dir}?: ")
 
         if resp.lower() == "yes":
 
             # Erase the directory
             overwrite = True
-            confirm = input(f"Are you sure you want to remove {project_dir}?: ")
+            confirm = input(f"Are you sure you want to remove {host_dir}?: ")
 
             if confirm.lower() == "yes":
                 shutil.rmtree(project_dir)

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -22,7 +22,7 @@ PROJECT_PATH = Path(TEMP_DIR) / Path("toto")
 PARSED = funcmodule.config_parser(CONFIGPATH / "test_conf.yaml")
 CONF_INFO = funcmodule.config_info(PARSED)
 DIRS_LIST = funcmodule.create_dirs_list(CONF_INFO)
-funcmodule.create_dirs(DIRS_LIST, PROJECT_PATH)
+funcmodule.create_dirs(DIRS_LIST, "", PROJECT_PATH)
 funcmodule.split_config(PARSED, PROJECT_PATH)
 
 # Read strings samples for hypothesis
@@ -239,18 +239,19 @@ class TestCreateDirs(unittest.TestCase):
             TypeError,
             funcmodule.create_dirs,
             {"1": "This is a scene!"},
+            ".",
             TEMP_DIR,
         )
         # The second test has a wrong path to create the directories.
         self.assertRaises(
-            TypeError, funcmodule.create_dirs, DIRS_LIST, ["path", "as", "list"]
+            TypeError, funcmodule.create_dirs, DIRS_LIST, ".", ["path", "as", "list"]
         )
 
     def test_return_type(self):
         """Testing that the returned value is of type `pathlib.Path`"""
         with tempfile.TemporaryDirectory() as temp:
             returned_path = funcmodule.create_dirs(
-                DIRS_LIST, temp + "/my_project"
+                DIRS_LIST, ".", temp + "/my_project"
             )
             # This next assert would probably fail on Windows.
             self.assertTrue(

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -22,7 +22,7 @@ PROJECT_PATH = Path(TEMP_DIR) / Path("toto")
 PARSED = funcmodule.config_parser(CONFIGPATH / "test_conf.yaml")
 CONF_INFO = funcmodule.config_info(PARSED)
 DIRS_LIST = funcmodule.create_dirs_list(CONF_INFO)
-funcmodule.create_dirs(DIRS_LIST, "", PROJECT_PATH)
+funcmodule.create_dirs(DIRS_LIST, ".", PROJECT_PATH)
 funcmodule.split_config(PARSED, PROJECT_PATH)
 
 # Read strings samples for hypothesis


### PR DESCRIPTION
## New

* `project_path` can be configured as a flag. closes #17
* Printing host paths instead of container paths to the user.

## Fix

* Second `yes/no` prompt in the `setup` command now works properly. closes #12